### PR TITLE
Set up .gitignore [7]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+/blib/
+/src/*.o
+/src/Makefile
+/resources/*.so
+/resources/*.dylib
+.precomp/
+/releases/
+/Zodiac-Chinese-*


### PR DESCRIPTION
Add .gitignore primarily to stop .precomp getting in the way of clean
messages.